### PR TITLE
feat: allow custom review prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ The MCP server exposes two tools:
 
 If you have any other use case requirements, feel free to open issue.
 
+## Review Prompt Configuration
+
+Default review templates are stored in `review_prompts.yaml` at the project root. You can edit this file or add new review scenarios:
+
+```yaml
+security: |
+  You are an expert code reviewer focusing on security aspects.
+  {custom_prompt}
+```
+
+Invoke it with:
+
+```python
+codex_review("security", work_dir, target)
+```
+
 ## Safety
 
 - **Safe Mode**: Default read-only operations protect your environment

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,8 +64,25 @@ MCP 服务器暴露两个工具：
 
 如有其他使用场景需求，欢迎提交 issue。
 
+## 自定义 Review 场景
+
+默认的 review 模板存放在项目根目录的 `review_prompts.yaml` 中。你可以修改此文件或新增场景，例如：
+
+```yaml
+security: |
+  专注于安全漏洞的代码审查。
+  {custom_prompt}
+```
+
+然后使用：
+
+```python
+codex_review("security", work_dir, target)
+```
+
 ## 安全性
 
 - 安全模式：默认只读操作，保护你的环境
 - 可写模式：需要完整能力时使用 `--yolo` 标志
 - 顺序执行：避免多代理并行操作产生冲突
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp[cli]>=1.12.4",
+    "PyYAML>=6.0",
 ]
 
 [project.scripts]

--- a/review_prompts.yaml
+++ b/review_prompts.yaml
@@ -1,0 +1,94 @@
+files: |
+  You are an expert code reviewer. Please conduct a thorough code review of the specified files.
+
+  Focus on:
+  - Code quality and best practices
+  - Potential bugs and security issues
+  - Performance considerations
+  - Maintainability and readability
+  - Design patterns and architecture
+
+  Files to review: {target}
+
+  {custom_prompt}
+
+  Please provide detailed feedback with specific suggestions for improvement.
+
+staged: |
+  You are an expert code reviewer. Please review the staged changes (git diff --cached) that are ready to be committed.
+
+  Focus on:
+  - Code quality and adherence to best practices
+  - Potential bugs introduced by the changes
+  - Security vulnerabilities
+  - Performance impact
+  - Breaking changes or compatibility issues
+  - Commit readiness
+
+  {custom_prompt}
+
+  Please provide feedback on whether these changes are ready for commit and any improvements needed.
+
+unstaged: |
+  You are an expert code reviewer. Please review the unstaged changes (git diff) in the working directory.
+
+  Focus on:
+  - Code quality and best practices
+  - Potential bugs and issues
+  - Incomplete implementations
+  - Code style and formatting
+  - Areas that need attention before staging
+
+  {custom_prompt}
+
+  Please provide feedback on the current changes and what should be addressed before committing.
+
+changes: |
+  You are an expert code reviewer. Please review the git changes in the specified commit range.
+
+  Focus on:
+  - Overall impact and coherence of the changes
+  - Code quality and best practices
+  - Potential regressions or bugs
+  - Security implications
+  - Performance impact
+  - Documentation needs
+
+  Commit range: {target}
+
+  {custom_prompt}
+
+  Please provide comprehensive feedback on these changes.
+
+pr: |
+  You are an expert code reviewer. Please conduct a comprehensive pull request review.
+
+  Focus on:
+  - Overall design and architecture decisions
+  - Code quality and best practices
+  - Test coverage and quality
+  - Documentation completeness
+  - Breaking changes and backward compatibility
+  - Security considerations
+  - Performance implications
+
+  Pull Request: {target}
+
+  {custom_prompt}
+
+  Please provide detailed review feedback suitable for a pull request review.
+
+general: |
+  You are an expert code reviewer. Please conduct a general code review of the codebase.
+
+  Focus on:
+  - Overall code architecture and design
+  - Code quality and maintainability
+  - Security best practices
+  - Performance optimization opportunities
+  - Technical debt identification
+  - Documentation quality
+
+  {custom_prompt}
+
+  Please provide a comprehensive review with prioritized recommendations.

--- a/src/codex_as_mcp/server.py
+++ b/src/codex_as_mcp/server.py
@@ -4,6 +4,8 @@ import re
 import argparse
 import sys
 from typing import List, Dict, Optional, Sequence
+from pathlib import Path
+import yaml
 
 # Global safe mode setting
 SAFE_MODE = True
@@ -82,8 +84,8 @@ def run_and_extract_codex_blocks(
     return blocks[-last_n:]
 
 
-# Pre-defined review prompts for different scenarios
-REVIEW_PROMPTS = {
+# Default review prompts for different scenarios
+DEFAULT_REVIEW_PROMPTS = {
     "files": """You are an expert code reviewer. Please conduct a thorough code review of the specified files.
 
 Focus on:
@@ -173,6 +175,29 @@ Focus on:
 
 Please provide a comprehensive review with prioritized recommendations."""
 }
+
+
+def load_review_prompts() -> Dict[str, str]:
+    """Load review prompts from project root YAML file.
+
+    Returns:
+        dict: Review prompt templates.
+    """
+    config_path = Path(__file__).resolve().parents[2] / "review_prompts.yaml"
+    try:
+        with config_path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+            if isinstance(data, dict):
+                return data
+    except FileNotFoundError:
+        pass
+    except Exception:
+        pass
+    return DEFAULT_REVIEW_PROMPTS
+
+
+# Loaded review prompts
+REVIEW_PROMPTS = load_review_prompts()
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary
- 将 review prompts 移动到 review_prompts.yaml，并支持自定义场景
- server 启动时读取该文件，缺失时回退到内置默认模板
- 文档新增如何在配置文件中添加自定义 review 场景的说明

## Testing
- `python -m py_compile src/codex_as_mcp/server.py`
- `python - <<'PY'\nimport sys\nsys.path.insert(0,'src')\nfrom codex_as_mcp import server\nprint('keys', sorted(server.REVIEW_PROMPTS.keys()))\nprint('files prompt first line:', server.REVIEW_PROMPTS['files'].splitlines()[0])\nPY`
- `mv review_prompts.yaml review_prompts.yaml.bak && python - <<'PY'\nimport sys, importlib\nsys.path.insert(0,'src')\nimport codex_as_mcp.server as s\nimportlib.reload(s)\nprint('keys', sorted(s.REVIEW_PROMPTS.keys()))\nPY && mv review_prompts.yaml.bak review_prompts.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68b0527de2f88330aca1f3e4ab852a95