### PR TITLE
feat: 支持自定义 Python 及虚拟环境路径

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest
 claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest --yolo
 ```
 
+### 3. Customize environment
+
+Copy the provided `env.config.json` and adjust dependencies, interpreter path or virtual env location as needed:
+
+```bash
+cp env.config.json my-env.json
+# edit my-env.json to change python version, packages, python_path or venv_path
+```
+
+Set `python_path` to the full path of a local interpreter (e.g., `F:\python310\python.exe` on Windows) and `venv_path` to where the virtual environment should be created. Running `main.py` will read `env.config.json` to create/activate that environment and install listed packages. If the file is missing, it falls back to `uv.lock`.
+
 ## Tools
 
 The MCP server exposes two tools:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,6 +56,17 @@ claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest
 claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest --yolo
 ```
 
+### 3. 自定义环境
+
+复制根目录的 `env.config.json` 并根据需要调整依赖、解释器路径或虚拟环境位置：
+
+```bash
+cp env.config.json my-env.json
+# 编辑 my-env.json 修改 Python 版本、依赖、python_path 或 venv_path
+```
+
+将 `python_path` 设置为本地解释器的完整路径（如 Windows 上的 `F:\python310\python.exe`），并将 `venv_path` 指向希望创建虚拟环境的位置。运行 `main.py` 时会优先读取 `env.config.json` 创建/激活该环境并安装依赖；若文件不存在则回退到 `uv.lock`。
+
 ## 工具
 
 MCP 服务器暴露两个工具：
@@ -69,3 +80,4 @@ MCP 服务器暴露两个工具：
 - 安全模式：默认只读操作，保护你的环境
 - 可写模式：需要完整能力时使用 `--yolo` 标志
 - 顺序执行：避免多代理并行操作产生冲突
+

--- a/env.config.json
+++ b/env.config.json
@@ -1,0 +1,8 @@
+{
+  "python": "3.11",
+  "python_path": "/usr/bin/python3",
+  "venv_path": ".venv",
+  "dependencies": {
+    "requests": "2.31.0"
+  }
+}

--- a/main.py
+++ b/main.py
@@ -1,6 +1,47 @@
-def main():
-    print("Hello from codex-as-mcp!")
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import shutil
 
+CONFIG_FILE = "env.config.json"
+VENV_DIR = ".venv"
+
+def ensure_env():
+    config_path = pathlib.Path(CONFIG_FILE)
+    if config_path.exists():
+        with config_path.open() as f:
+            data = json.load(f)
+        python_cmd = data.get("python", "python3")
+        python_path = data.get("python_path")
+        venv_dir = data.get("venv_path", VENV_DIR)
+        deps = data.get("dependencies", {})
+        venv_python = pathlib.Path(venv_dir) / ("Scripts" if os.name == "nt" else "bin") / "python"
+        if pathlib.Path(sys.executable).resolve() != venv_python.resolve():
+            if not venv_python.exists():
+                if python_path:
+                    python_exe = python_path
+                else:
+                    python_exe = shutil.which(python_cmd) or sys.executable
+                subprocess.check_call([str(python_exe), "-m", "venv", venv_dir])
+            os.execv(str(venv_python), [str(venv_python), *sys.argv])
+        if deps:
+            subprocess.check_call([str(venv_python), "-m", "ensurepip", "--upgrade"])
+            packages = [f"{name}=={ver}" for name, ver in deps.items()]
+            subprocess.check_call([str(venv_python), "-m", "pip", "install", *packages])
+    else:
+        lock_file = pathlib.Path("uv.lock")
+        if lock_file.exists():
+            try:
+                subprocess.check_call(["uv", "pip", "install", "-r", str(lock_file)])
+            except FileNotFoundError:
+                print("未找到 uv 命令，无法根据 uv.lock 安装依赖", file=sys.stderr)
+
+def main():
+    ensure_env()
+    print("Hello from codex-as-mcp!")
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- 在 `env.config.json` 中新增 `venv_path` 字段，可自定义虚拟环境位置
- 更新 `main.py` 读取 `venv_path`，在指定目录创建或激活环境
- 中英双语文档补充 `venv_path` 的配置说明

## Testing
- `python -m py_compile main.py`
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0538d301483309195f39c2e0a8708