### PR TITLE
feat: add auto approve option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ Add to your `.mcp.json`:
 }
 ```
 
+**Writable Mode with Auto Approval (dangerous):**
+```json
+{
+  "mcpServers": {
+    "codex": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["codex-as-mcp@latest", "--yolo", "--auto-approve"]
+    }
+  }
+}
+```
+
 Or use Claude Code commands:
 ```bash
 # Safe mode (default)
@@ -56,6 +69,9 @@ claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest
 
 # Writable mode
 claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest --yolo
+
+# Writable mode with auto approve (dangerous)
+claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest --yolo --auto-approve
 ```
 
 ## Tools
@@ -70,4 +86,5 @@ If you have any other use case requirements, feel free to open issue.
 
 - **Safe Mode**: Default read-only operations protect your environment
 - **Writable Mode**: Use `--yolo` flag when you need full codex capabilities
+- **Auto Approval**: `--auto-approve` skips all confirmation prompts. ⚠️ May execute destructive actions without warning.
 - **Sequential Execution**: Prevents conflicts from parallel agent operations

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,6 +47,19 @@ codex --version
 }
 ```
 
+【可写模式并自动同意（危险）】
+```json
+{
+  "mcpServers": {
+    "codex": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["codex-as-mcp@latest", "--yolo", "--auto-approve"]
+    }
+  }
+}
+```
+
 或者使用 Claude Code 命令：
 ```bash
 # 安全模式（默认）
@@ -54,6 +67,9 @@ claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest
 
 # 可写模式
 claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest --yolo
+
+# 可写模式并自动同意（危险）
+claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest --yolo --auto-approve
 ```
 
 ## 工具
@@ -68,4 +84,5 @@ MCP 服务器暴露两个工具：
 
 - 安全模式：默认只读操作，保护你的环境
 - 可写模式：需要完整能力时使用 `--yolo` 标志
+- 自动同意：使用 `--auto-approve` 跳过所有确认。⚠️ 可能执行具有破坏性的操作，谨慎使用
 - 顺序执行：避免多代理并行操作产生冲突


### PR DESCRIPTION
## Summary
- add global `AUTO_APPROVE` flag and `--auto-approve` CLI option
- append auto-approval flags and env vars when executing codex
- document auto-approve usage and risks in READMEs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b0576d36688330b08bbe13905a1429