### PR TITLE
feat: 支持命令超时设置

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest
 
 # Writable mode
 claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest --yolo
+
+# Custom timeout (default 300s)
+claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest --timeout 600
 ```
 
 ## Tools

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,6 +54,9 @@ claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest
 
 # 可写模式
 claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest --yolo
+
+# 自定义超时（默认 300 秒）
+claude mcp add codex-as-mcp -- uvx codex-as-mcp@latest --timeout 600
 ```
 
 ## 工具


### PR DESCRIPTION
## Summary
- 允许自定义 Codex 子进程超时并在超时后给出提示
- 新增 `--timeout` 参数，支持 CLI 传入默认超时
- 更新文档说明自定义超时用法

## Testing
- `python -m pytest`
- `python src/codex_as_mcp/server.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68b057549cb48330b30337b446deff1a